### PR TITLE
Support workspace level configuration files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,10 @@ stack install stylish-haskell hindent
 2. Add .stylish-haskell config autosearch
 3. Binary paths configs in VSCode
 
+## CHANGES
+
+v0.0.3
+
+Note the working directory of the hindent and stylish-haskell will be
+the top level workspace directory and any `.hindent.yaml` or `stylish-haskell.yaml`
+will be picked up from there.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/sergey-kintsel/haskell-vscode-formatter"
   },
   "displayName": "Haskell Code Formatter",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "The Haskell code formatter that applies both hindent and stylish-haskell",
   "author": "Sergey Kintsel",
   "publisher": "sergey-kintsel",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,18 +5,19 @@ const haskellLangId = 'haskell';
 export function activate(context: vscode.ExtensionContext) {
   vscode.languages.registerDocumentRangeFormattingEditProvider(haskellLangId, {
     provideDocumentRangeFormattingEdits(document, range, options, token) {
+      const cwd = vscode.workspace.rootPath;
       const showErrorMessage = (friendlyText, error) => {
         vscode.window.showErrorMessage(`${friendlyText}\n${error.stderr.toString()}`);
         return [];
       }
 
       try {
-        proc.execSync('hindent --help');
+        proc.execSync('hindent --help', {cwd: cwd});
       } catch (e) {
         return showErrorMessage("HIndent is not installed", e);
       }
       try {
-        proc.execSync('stylish-haskell --help');
+        proc.execSync('stylish-haskell --help', {cwd: cwd});
       } catch (e) {
         return showErrorMessage("stylish-haskell is not installed", e);
       }
@@ -24,13 +25,13 @@ export function activate(context: vscode.ExtensionContext) {
       const text = document.getText(range);
       let hindentedText;
       try {
-        hindentedText = proc.execSync('hindent', {input: text}).toString();
+        hindentedText = proc.execSync('hindent', {input: text, cwd: cwd}).toString();
       } catch (e) {
         return showErrorMessage('hindent failed to format the code', e);
       }
       let styledText;
       try {
-        styledText = proc.execSync('stylish-haskell', {input: hindentedText}).toString();
+        styledText = proc.execSync('stylish-haskell', {input: hindentedText, cwd: cwd}).toString();
       } catch (e) {
         return showErrorMessage('stylish-haskell failed to format the code', e);
       }


### PR DESCRIPTION
This should allow `.hindent.yaml` or `stylish-haskell.yaml` to be picked up from the top level workspace folder.